### PR TITLE
feat: add timezone message and timezones service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_message_files(
     EventSchedulerArray.msg
     HandlerInfo.msg
     LoopStatus.msg
+    Timezone.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -50,6 +51,7 @@ add_service_files(
     GetCommandSchedulerList.srv
     AddSchedule.srv
     GetHandlerInfoList.srv
+    Timezones.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/msg/EventScheduler.msg
+++ b/msg/EventScheduler.msg
@@ -1,10 +1,11 @@
 string id
 int32[] wk
-string date_start
-string date_end
+string start_date
+string end_date
 int32 hour
 int32 minute
 int32 repeat_hour
 bool enabled
 string commands
+string timezone
 

--- a/msg/Timezone.msg
+++ b/msg/Timezone.msg
@@ -1,0 +1,2 @@
+string zone
+float32 offset

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robot_simple_command_manager_msgs</name>
-  <version>2.0.0</version>
+  <version>1.0.0</version>
   <description>The robot_simple_command_manager_msgs package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robot_simple_command_manager_msgs</name>
-  <version>0.10.0</version>
+  <version>2.0.0</version>
   <description>The robot_simple_command_manager_msgs package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/srv/Timezones.srv
+++ b/srv/Timezones.srv
@@ -1,0 +1,4 @@
+---
+Timezone[] timezones
+bool success
+string message


### PR DESCRIPTION
This pull request includes several changes to add support for timezones in the scheduling system. The most important changes include adding new message and service files, as well as updating existing message definitions to include timezone information.

### Additions to message and service files:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR38): Added `Timezone.msg` to the list of message files and `Timezones.srv` to the list of service files. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR38) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR54)

### Updates to existing message definitions:

* [`msg/EventScheduler.msg`](diffhunk://#diff-6c24b98a222685e8f6d4a55aaa55e3b82e558ef8ce2233a07cb204c06a17c077L3-R10): Renamed `date_start` and `date_end` to `start_date` and `end_date`, respectively, and added a new `timezone` field.

### New message and service definitions:

* [`msg/Timezone.msg`](diffhunk://#diff-e6b1baba25bcf3315c87e146779d61c3231ad793f37f0cbaa2ba2fdb50343acdR1-R2): Added a new message definition with fields `zone` and `offset`.
* [`srv/Timezones.srv`](diffhunk://#diff-3ff458588e47c6e0e95b6b7507b8b36291c2ccbc6698af56b0d10fbca4f54bc2R1-R4): Added a new service definition with fields `timezones`, `success`, and `message`.…essage